### PR TITLE
Add support for scheduling reports for nightly crons

### DIFF
--- a/Koha/Plugin/Fi/NatLib/PatronEmailer.pm
+++ b/Koha/Plugin/Fi/NatLib/PatronEmailer.pm
@@ -17,7 +17,7 @@ use DateTime;
 use Digest::MD5 qw(md5_hex);
 use File::Basename;
 use List::Util qw( any );
-use Mojo::JSON qw(decode_json);
+use Mojo::JSON qw(encode_json decode_json);
 use Text::CSV;
 
 use Template;
@@ -263,16 +263,107 @@ sub tool_step2 {
         }
     }
 
+    my $report_id       = $cgi->param("report_id");
+    my $schedule_notice = $cgi->param("schedule_notice") ? 1           : 0;
+    my $notice_id       = $notice                        ? $notice->id : undef;
+    my $opts            = {
+        add_unsubscribe_link => $add_unsubscribe_link,
+        notice_id            => $notice_id,
+        report_id            => $report_id,
+    };
+    $opts = encode_json($opts);
 
     $template->param(
         not_found => \@not_found,
         sent      => \@to_send,
         is_html   => $is_html,
         letter_code => 'PEP_' . $letter_code,
+        opts            => $opts,
+        schedule_notice => $schedule_notice,
     );
 
     print $cgi->header("text/html;charset=UTF-8");
     print $template->output();
+}
+
+sub schedule_notice {
+    my ( $self, $opts ) = @_;
+
+    $opts ||= {};
+
+    return unless $opts->{report_id};
+    return unless $opts->{notice_id};
+
+    my $scheduled_notices_json = $self->retrieve_data('scheduled_notices');
+    $scheduled_notices_json ||= '{}';
+    my $scheduled_notices = decode_json($scheduled_notices_json);
+
+    my $key = 'report_id_' . $opts->{report_id} . '_notice_id_' . $opts->{notice_id};
+    $scheduled_notices->{$key} = $opts;
+    $opts->{scheduled_on} = dt_from_string;
+
+    $self->store_data(
+        {
+            'scheduled_notices' => encode_json($scheduled_notices),
+        }
+    );
+}
+
+sub cronjob_nightly {
+    my ($self) = @_;
+
+    my $scheduled_notices_json = $self->retrieve_data('scheduled_notices');
+    return 1 unless $scheduled_notices_json;
+
+    my $scheduled_notices = decode_json($scheduled_notices_json);
+
+    my $schema = Koha::Database->new()->schema();
+
+    my $message_queue_rs = $schema->resultset('MessageQueue');
+    foreach my $key ( keys %$scheduled_notices ) {
+        my $scheduled_notice     = $scheduled_notices->{$key};
+        my $notice_id            = $scheduled_notice->{notice_id};
+        my $add_unsubscribe_link = $scheduled_notice->{add_unsubscribe_link} || 0;
+        my $notice               = Koha::Notice::Templates->find( { id => $notice_id } );
+        my $body_template        = $notice->content;
+        my $subject              = $notice->title;
+        my $letter_code          = $notice->code;
+        my $is_html              = $notice->is_html;
+        my $report_id            = $scheduled_notice->{report_id};
+        my $report               = Koha::Reports->find($report_id);
+        my $sql                  = $report->savedsql;
+        my ( $sth, $errors );
+
+        if ( C4::Context->preference('Version') ge '21.060000' ) {
+            ( $sth, $errors ) =
+                execute_query( { sql => $sql } );   #don't pass offset or limit, hardcoded limit of 999,999 will be used
+        } else {
+            ( $sth, $errors ) =
+                execute_query($sql);                #don't pass offset or limit, hardcoded limit of 999,999 will be used
+        }
+
+        while ( my $row = $sth->fetchrow_hashref() ) {
+            unless ( defined $row->{cardnumber} ) {
+                warn "report_id $report_id, notice_id $notice_id: no cardnumber";
+                last;
+            }
+            my $email = generate_email( $row, $body_template, $subject, $is_html, $notice, $add_unsubscribe_link );
+            $message_queue_rs->create(
+                {
+                    borrowernumber => $email->{borrowernumber},
+                    subject        => $email->{subject},
+                    content        => $is_html ? _wrap_html( $email->{content}, $email->{subject} ) : $email->{content},
+                    ( $is_html ? ( content_type => 'text/html; charset="UTF-8"' ) : () ),
+                    message_transport_type => $email->{to_address} ? 'email' : 'print',
+                    status                 => $email->{status},
+                    to_address             => $email->{to_address},
+                    from_address           => $email->{from_address},
+                    letter_code            => $email->{code} || 'PEP',
+                    time_queued            => dt_from_string,
+                }
+            );
+        }
+    }
 }
 
 sub generate_email {
@@ -317,7 +408,7 @@ sub generate_email {
             content                => $body,
             message_transport_type => 'email',
             status                 => 'pending',
-            to_address             => $line->{email},
+            to_address             => $line->{email} || $borrower->email,
             from_address           => $line->{from} || C4::Context->preference('KohaAdminEmailAddress'),
             branchcode => $branchcode,
             module => $module,
@@ -344,6 +435,7 @@ sub tool_step3 {
     my $schema           = Koha::Database->new()->schema();
     my $message_queue_rs = $schema->resultset('MessageQueue');
     my $letter_code = $cgi->param('letter_code');
+    my $notice_id = $cgi->param('notice_id');
     my $is_html = $cgi->param('is_html');
     for( my $i = 0; $i < @borrowernumber; $i++ ){
         my $key = "unsub-$borrowernumber[$i]-$module[$i],$code[$i]";
@@ -368,6 +460,15 @@ sub tool_step3 {
 
     }
     $template->param( sent => 1 );
+
+    my $opts_param      = $cgi->param("opts");
+    my $opts            = decode_json($opts_param);
+    my $schedule_notice = $cgi->param("schedule_notice") ? 1 : 0;
+    if ( $schedule_notice && $opts->{report_id} && $opts->{notice_id} ) {
+        $self->schedule_notice($opts);
+        $template->param(scheduled => 1);
+    }
+
     print $cgi->header("text/html;charset=UTF-8");
     print $template->output();
 }
@@ -394,10 +495,39 @@ sub configure {
         $template->param( is_html   => $self->retrieve_data('is_html'), );
         $template->param( delimiter => $delimiter, );
 
+        my $scheduled_notices_json = $self->retrieve_data('scheduled_notices');
+        $scheduled_notices_json ||= '{}';
+        my $scheduled_notices = decode_json($scheduled_notices_json);
+        foreach my $key ( keys %$scheduled_notices ) {
+            $scheduled_notices->{$key}->{id} = $key;
+            $scheduled_notices->{$key}->{id} =~ /report_id_(\d+)_notice_id_(\d+)/;
+            my ( $report_id, $notice_id ) = ( $1, $2 );
+            my $report      = Koha::Reports->find($report_id);
+            my $report_name = $report ? $report->report_name : '-';
+            my $notice      = Koha::Notice::Templates->find( { id => $notice_id } );
+            my $letter_code = $notice ? $notice->code : '-';
+            $scheduled_notices->{$key}->{report_name} = $report_name;
+            $scheduled_notices->{$key}->{letter_code} = $letter_code;
+        }
+        $template->param( scheduled_notices => $scheduled_notices );
+
         print $cgi->header("text/html;charset=UTF-8");
         print $template->output();
     }
     else {
+        my $scheduled_notices_json = $self->retrieve_data('scheduled_notices');
+        $scheduled_notices_json ||= '{}';
+        my $scheduled_notices = decode_json($scheduled_notices_json);
+
+        foreach my $param_key ( keys %{ $cgi->Vars } ) {
+            if ( $param_key =~ /^delete_report_id_(\d+)_notice_id_(\d+)$/ && $cgi->param($param_key) ) {
+                $param_key =~ s/^delete_//;
+                delete $scheduled_notices->{$param_key};
+            }
+        }
+
+        $scheduled_notices_json = encode_json($scheduled_notices);
+
         $self->store_data(
             {
                 body               => $cgi->param('body')|| "",
@@ -405,6 +535,7 @@ sub configure {
                 delimiter          => $cgi->param('delimiter') || "",
                 is_html            => $cgi->param('is_html') || "",
                 last_configured_by => C4::Context->userenv->{number},
+                scheduled_notices  => $scheduled_notices_json,
             }
         );
     }

--- a/Koha/Plugin/Fi/NatLib/PatronEmailer.pm
+++ b/Koha/Plugin/Fi/NatLib/PatronEmailer.pm
@@ -263,13 +263,15 @@ sub tool_step2 {
         }
     }
 
+    my $notice_id       = $notice ? $notice->id : undef;
     my $report_id       = $cgi->param("report_id");
-    my $schedule_notice = $cgi->param("schedule_notice") ? 1           : 0;
-    my $notice_id       = $notice                        ? $notice->id : undef;
+    my $schedule_notice = $cgi->param("schedule_notice") ? 1 : 0;
+    my $use_built_in    = $cgi->param('use_built_in')    ? 1 : 0;
     my $opts            = {
         add_unsubscribe_link => $add_unsubscribe_link,
         notice_id            => $notice_id,
         report_id            => $report_id,
+        use_built_in         => $use_built_in,
     };
     $opts = encode_json($opts);
 
@@ -292,13 +294,14 @@ sub schedule_notice {
     $opts ||= {};
 
     return unless $opts->{report_id};
-    return unless $opts->{notice_id};
+    return if !$opts->{notice_id} && !$opts->{use_built_in};
 
     my $scheduled_notices_json = $self->retrieve_data('scheduled_notices');
     $scheduled_notices_json ||= '{}';
     my $scheduled_notices = decode_json($scheduled_notices_json);
 
-    my $key = 'report_id_' . $opts->{report_id} . '_notice_id_' . $opts->{notice_id};
+    my $notice_id = $opts->{notice_id} ? $opts->{notice_id} : 'BUILT_IN';
+    my $key       = 'report_id_' . $opts->{report_id} . '_notice_id_' . $notice_id;
     $scheduled_notices->{$key} = $opts;
     $opts->{scheduled_on} = dt_from_string;
 
@@ -324,14 +327,22 @@ sub cronjob_nightly {
         my $scheduled_notice     = $scheduled_notices->{$key};
         my $notice_id            = $scheduled_notice->{notice_id};
         my $add_unsubscribe_link = $scheduled_notice->{add_unsubscribe_link} || 0;
-        my $notice               = Koha::Notice::Templates->find( { id => $notice_id } );
-        my $body_template        = $notice->content;
-        my $subject              = $notice->title;
-        my $letter_code          = $notice->code;
-        my $is_html              = $notice->is_html;
-        my $report_id            = $scheduled_notice->{report_id};
-        my $report               = Koha::Reports->find($report_id);
-        my $sql                  = $report->savedsql;
+        my ( $notice, $body_template, $subject, $letter_code, $is_html );
+        if ( "$notice_id" eq 'BUILT_IN' ) {
+            $body_template = $self->retrieve_data('body');
+            $subject       = $self->retrieve_data('subject');
+            $is_html       = $self->retrieve_data('is_html');
+            $letter_code   = "BUILT_IN";
+        } else {
+            $notice        = Koha::Notice::Templates->find( { id => $notice_id } );
+            $body_template = $notice->content;
+            $subject       = $notice->title;
+            $letter_code   = $notice->code;
+            $is_html       = $notice->is_html;
+        }
+        my $report_id = $scheduled_notice->{report_id};
+        my $report    = Koha::Reports->find($report_id);
+        my $sql       = $report->savedsql;
         my ( $sth, $errors );
 
         if ( C4::Context->preference('Version') ge '21.060000' ) {
@@ -464,9 +475,9 @@ sub tool_step3 {
     my $opts_param      = $cgi->param("opts");
     my $opts            = decode_json($opts_param);
     my $schedule_notice = $cgi->param("schedule_notice") ? 1 : 0;
-    if ( $schedule_notice && $opts->{report_id} && $opts->{notice_id} ) {
+    if ( $schedule_notice && $opts->{report_id} && ( $opts->{notice_id} || $opts->{use_built_in} ) ) {
         $self->schedule_notice($opts);
-        $template->param(scheduled => 1);
+        $template->param( scheduled => 1 );
     }
 
     print $cgi->header("text/html;charset=UTF-8");
@@ -500,12 +511,19 @@ sub configure {
         my $scheduled_notices = decode_json($scheduled_notices_json);
         foreach my $key ( keys %$scheduled_notices ) {
             $scheduled_notices->{$key}->{id} = $key;
-            $scheduled_notices->{$key}->{id} =~ /report_id_(\d+)_notice_id_(\d+)/;
+            $scheduled_notices->{$key}->{id} =~ /report_id_(\d+)_notice_id_([0-9A-Z_]+)/;
             my ( $report_id, $notice_id ) = ( $1, $2 );
             my $report      = Koha::Reports->find($report_id);
             my $report_name = $report ? $report->report_name : '-';
-            my $notice      = Koha::Notice::Templates->find( { id => $notice_id } );
-            my $letter_code = $notice ? $notice->code : '-';
+            my $letter_code;
+            if ( $notice_id =~ /^\d+$/ ) {
+                my $notice = Koha::Notice::Templates->find( { id => $notice_id } );
+                $letter_code = $notice ? $notice->code : '-';
+            } elsif ( $notice_id eq 'BUILT_IN' ) {
+                $letter_code = $notice_id;
+            } else {
+                $letter_code = '-';
+            }
             $scheduled_notices->{$key}->{report_name} = $report_name;
             $scheduled_notices->{$key}->{letter_code} = $letter_code;
         }
@@ -520,7 +538,7 @@ sub configure {
         my $scheduled_notices = decode_json($scheduled_notices_json);
 
         foreach my $param_key ( keys %{ $cgi->Vars } ) {
-            if ( $param_key =~ /^delete_report_id_(\d+)_notice_id_(\d+)$/ && $cgi->param($param_key) ) {
+            if ( $param_key =~ /^delete_report_id_(\d+)_notice_id_([0-9A-Z_]+)$/ && $cgi->param($param_key) ) {
                 $param_key =~ s/^delete_//;
                 delete $scheduled_notices->{$param_key};
             }

--- a/Koha/Plugin/Fi/NatLib/PatronEmailer/configure.tt
+++ b/Koha/Plugin/Fi/NatLib/PatronEmailer/configure.tt
@@ -78,6 +78,31 @@ Last name: [% lastname %]
             </pre>
 
 
+            <p>
+            <h3 id="delete_scheduled">Delete scheduled notices</h3>
+            <table>
+            <thead>
+            <tr>
+            <th>ID</th>
+            <th>Report name</th>
+            <th>Letter code</th>
+            <th>Scheduled on</th>
+            <th>Delete</th>
+            </tr>
+            </thead>
+            <tbody>
+            [% FOREACH sr_key IN scheduled_notices.keys %]
+            <tr>
+            <td><label for="delete_[% scheduled_notices.$sr_key.id | html %]">[% scheduled_notices.$sr_key.id | html %]</label></td>
+            <td>[% scheduled_notices.$sr_key.report_name %]</td>
+            <td>[% scheduled_notices.$sr_key.letter_code %]</td>
+            <td>[% scheduled_notices.$sr_key.scheduled_on %]</td>
+            <td><input type="checkbox" name="delete_[% scheduled_notices.$sr_key.id | html %]" id="delete_[% scheduled_notices.$sr_key.id | html %]" /></td>
+            </tr>
+            [% END %]
+            </tbody>
+            </table>
+            </p>
             <input type="hidden" name="save" value="1" />
 
             <input type="submit" value="Save configuration" />

--- a/Koha/Plugin/Fi/NatLib/PatronEmailer/tool-step1.tt
+++ b/Koha/Plugin/Fi/NatLib/PatronEmailer/tool-step1.tt
@@ -88,7 +88,7 @@
                     <option data-branch="[% letter.branchcode | html %]" data-module="[% letter.module | html %]" value="[% letter.id | html %]">[% letter.name | html %] ( [% Branches.GetName(letter.branchcode) || "All" | html %] | [% letter.module | html %] | [% letter.message_transport_type | html %] ) </option>
                 [% END %]
             </select>
-            </p>
+            </p> 
 
         </fieldset>
 
@@ -96,6 +96,11 @@
             <legend>Preferences</legend>
             <label for="add_unsubscribe_link">Add unsubscribe hash link at the end of the message:</label>
             <input id="add_unsubscribe_link" type="checkbox" name="add_unsubscribe_link">
+            <br />
+            <label for="schedule_notice">Schedule this notice to be run daily:</label>
+            <input id="schedule_notice" type="checkbox" name="schedule_notice">
+            <br />
+            <p>To delete a scheduled notice, please navigate to <a href="/cgi-bin/koha/plugins/run.pl?class=Koha%3A%3APlugin%3A%3AFi%3A%3ANatLib%3A%3APatronEmailer&method=configure#delete_scheduled" target="_blank">plugin configuration</a>.
         </fieldset>
 
         <input name="submitted" type="submit" value="Next..." />

--- a/Koha/Plugin/Fi/NatLib/PatronEmailer/tool-step2.tt
+++ b/Koha/Plugin/Fi/NatLib/PatronEmailer/tool-step2.tt
@@ -68,6 +68,8 @@
                 <input type="hidden" name="branchcode" value="[% email.branchcode | html %]" />
                 <input type="hidden" name="module" value="[% email.module | html %]" />
                 <input type="hidden" name="code" value="[% email.code | html %]" />
+                <input type="hidden" name="opts" value="[% opts | html %]" />
+                <input type="hidden" name="schedule_notice" value="[% schedule_notice | html %]" />
             </td>
             <td>[% email.subject | html %]<input type="hidden" name="subject" value="[% email.subject | html %]" /></td>
             <td>
@@ -84,7 +86,27 @@
     [% END %]
     </tbody>
 </table>
+  <label for="schedule_notice">Schedule this notice to be run daily:</label>
+  <input id="schedule_notice" type="checkbox" name="schedule_notice"[% IF schedule_notice %] checked="checked"[% END %]>
+  <br />
   <input type="submit" value="Send emails"/>
+</form>
+[% ELSIF ( schedule_notice && !no_cardnumber ) %]
+<div class="main container-fluid" id="doc3">
+    No cardnumbers were currently retrieved, but we can still schedule this report:
+</div>
+<form method="post" enctype="multipart/form-data">
+    [% IF koha_version >= '24.05'; INCLUDE 'csrf-token.inc'; END %]
+    <input type="hidden" name="op" value="cud-pep_save"/>
+    <input type="hidden" name="class" value="[% CLASS | html %]"/>
+    <input type="hidden" name="method" value="[% METHOD | html %]"/>
+    <input type="hidden" name="step3" value="step3"/>
+    <input type="hidden" name="letter_code" value="[% letter_code | html %]"/>
+    <input type="hidden" name="is_html" value="[% is_html | html %]"/>
+    <input type="hidden" name="opts" value="[% opts | html %]" />
+  <input id="schedule_notice" type="hidden" name="schedule_notice" value="1">
+  <br />
+  <input type="submit" value="Schedule report"/>
 </form>
 [% END %]
 [% IF ( no_cardnumber ) %]

--- a/Koha/Plugin/Fi/NatLib/PatronEmailer/tool-step3.tt
+++ b/Koha/Plugin/Fi/NatLib/PatronEmailer/tool-step3.tt
@@ -25,7 +25,8 @@
 
 [% IF ( sent) %]
 <div class="main container-fluid" id="doc3">
-    Your emails have been scheduled for delivery!
+    <p>Your emails have been scheduled for delivery!</p>
+    [% IF ( scheduled ) %]<p>This email has been scheduled to be run daily.</p>[% END %]
 </div>
 [% END %]
 

--- a/README.md
+++ b/README.md
@@ -50,3 +50,16 @@ To send the emails:
  * Ensure the message is setup as you wish
  * Click Actions -> Run
  * Upload the CSV file you saved in step 2
+
+## Scheduling reports
+
+This plugin is able to use the `plugins_nightly.pl` cronjob.
+
+It allows you to create an SQL report and have it email patrons daily.
+
+To do it:
+1. Create a SQL report
+2. Navigate to Tools->[KK-fork] Patron Emailer
+3. Enter report id
+4. Choose a notice
+5. Check "Schedule this report to be run daily"


### PR DESCRIPTION
Introduces a new checkbox Schedule this notice to be run daily to the tool's first page. By checking it, it stores the selected SQL report id and notice to be message_queue'd during plugins_nightly.pl cronjob.

This opens doors to new extremely useful notices. Our most requested one was the ability to send patron a request to check-in an item that has recently received new holds. You could also now create unlimited number of additional ODUE messages in addition to the standrad three.